### PR TITLE
fix length of FrozenDict

### DIFF
--- a/src/CompressHashDisplace.jl
+++ b/src/CompressHashDisplace.jl
@@ -113,7 +113,7 @@ struct FrozenDict{K, V} <: AbstractDict{K, V}
     ks::Vector{K}
     G::Vector{Int}
     values::Vector{V}
-    sz::UInt64
+    sz::Int
 end
 
 """
@@ -196,12 +196,12 @@ function FrozenDict(dict::Dict{K, V}) where {K, V}
         idx += 1
     end
 
-    return FrozenDict{K, V}(ks, G, values, sz)
+    return FrozenDict{K, V}(ks, G, values, length(dict))
 end
 
 # Look up a value in the hash table, defined by G and V.
 function Base.:getindex(FD::FrozenDict{K, V}, key) where {K, V}
-    szmask = UInt64(FD.sz - 1)
+    szmask = UInt64(length(FD.ks) - 1)
     idx = mmhash(key, 0%UInt32)
     @inbounds d = FD.G[idx & szmask + 1%UInt32]
     idx = d < 0 ? -d%UInt64 : (idx >> d) & szmask + 1%UInt64

--- a/src/CompressHashDisplace.jl
+++ b/src/CompressHashDisplace.jl
@@ -113,7 +113,7 @@ struct FrozenDict{K, V} <: AbstractDict{K, V}
     ks::Vector{K}
     G::Vector{Int}
     values::Vector{V}
-    sz::Int
+    sz::UInt64
 end
 
 """
@@ -196,12 +196,12 @@ function FrozenDict(dict::Dict{K, V}) where {K, V}
         idx += 1
     end
 
-    return FrozenDict{K, V}(ks, G, values, length(dict))
+    return FrozenDict{K, V}(ks, G, values, sz)
 end
 
 # Look up a value in the hash table, defined by G and V.
 function Base.:getindex(FD::FrozenDict{K, V}, key) where {K, V}
-    szmask = UInt64(length(FD.ks) - 1)
+    szmask = UInt64(FD.sz - 1)
     idx = mmhash(key, 0%UInt32)
     @inbounds d = FD.G[idx & szmask + 1%UInt32]
     idx = d < 0 ? -d%UInt64 : (idx >> d) & szmask + 1%UInt64

--- a/test/test02_iterate.jl
+++ b/test/test02_iterate.jl
@@ -1,0 +1,30 @@
+module TestIterate
+using CompressHashDisplace
+using Test
+
+@testset "FrozenDict iterate" begin
+    dict = Dict("test$i" => i for i = 1:10)
+    fdict = FrozenDict(dict)
+
+    @test length(fdict) == length(dict)
+    i = 0
+    for (k, v) in fdict
+        @test v == dict[k]
+        i += 1
+    end
+    @test i == length(fdict)
+end
+@testset "Nonstring iterate" begin
+    dict = Dict(i => 2i for i = 1:10)
+    fdict = FrozenDict(dict)
+
+    @test length(fdict) == length(dict)
+    i = 0
+    for (k, v) in fdict
+        @test v == dict[k]
+        i += 1
+    end
+    @test i == length(fdict)
+end
+
+end # module


### PR DESCRIPTION
We need a functioning length() to get the iterators to behave correctly. Since all arrays inside FrozenDict are potentially larger than the number of elements in the dict, we need to store the length of the original array.

This change was already introduced in my previous PR and later reverted in 2b981b94. If you object to altering the meaning of the `sz` variable, we can also add a new element to the FrozenDict struct specifically for storing the number of elements.